### PR TITLE
fix: add max-width to food image

### DIFF
--- a/src/components/Food/styles.js
+++ b/src/components/Food/styles.js
@@ -21,6 +21,8 @@ export const Container = styled.div`
     img {
       pointer-events: none;
       user-select: none;
+      max-width: 100%;
+      display: block;
     }
   }
 


### PR DESCRIPTION
Fazendo o desafio percebi que o tamanho imagem desfigurava o grid.

![go-restaurant-card-img-pull-request](https://user-images.githubusercontent.com/66652584/125843850-bc2ed399-3135-430b-a401-787b04162c17.png)

Com essas classes, foi corrigido o comportamento:

![go-restaurant-card-img-pull-request-after](https://user-images.githubusercontent.com/66652584/125843972-9b0856c4-dfff-41d4-9b5d-fcd037644446.png)
